### PR TITLE
Fix SSH profile inheritance and navigation persistence

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -833,6 +833,7 @@ export default function App() {
     shell?: any; // Shell and environment settings
     advanced?: any; // Advanced SSH settings
     os?: string; // OS from profile
+    _resolved?: boolean; // Flag indicating settings are already resolved with inheritance
   }) {
     try {
       // Ensure we have a usable auth. Some profiles may load with encrypted fields until master key is unlocked.
@@ -840,8 +841,9 @@ export default function App() {
         return !!(a && (a.agent || (a.password && a.password.length) || a.keyPath));
       }
       let authToUse = opts.auth;
-      // Always try to get fresh profile data when we have a profileId
-      if (opts.profileId) {
+      
+      // Skip re-fetching if settings are already resolved (from openProfile with inheritance)
+      if (!opts._resolved && opts.profileId) {
         try {
           const { getSshProfiles } = await import('@/store/persist');
           const profiles = await getSshProfiles();


### PR DESCRIPTION
## Summary
Fixes two critical issues with SSH profiles and navigation:
- **Issue #14**: SSH profiles with inheritance fail to connect due to encryption errors
- **Issue #15**: Navigation jumps to root when connecting to profiles in folders

## Root Cause Analysis

### Issue #14 - Profile Inheritance with Encryption
- `getSshProfiles()` was reloading from disk on every call (no caching)
- When profiles were encrypted, the reload would get encrypted data
- Inheritance data was lost when `openSshFor` re-fetched the profile

### Issue #15 - Navigation State Loss
- `currentFolderId` was reset to root whenever the tree loaded
- No persistence of navigation state between component re-renders

## Solution

### In-Memory Profile Cache
- Added cache to store decrypted profiles after first load
- Cache is cleared when profiles are unlocked (forcing fresh decrypted data)
- Prevents constant disk reads and ensures decrypted data stays in memory

### Profile Inheritance Fix
- Pass complete resolved settings from `openProfile` to `openSshFor`
- Added `_resolved` flag to skip re-fetching when data is already resolved
- Ensures inherited settings (including auth) work correctly

### Navigation Persistence
- Save `currentFolderId` to localStorage when it changes
- Restore navigation state when Sessions component mounts
- Only reset to root if saved folder doesn't exist in tree

## Changes Made

### `/src/store/persist.ts`
- Added `profilesCache` for in-memory storage
- Modified `loadAppState()` to use cache when available
- Modified `saveAppState()` to update cache immediately
- Added `reloadProfilesFromDisk()` for forced refresh after unlock

### `/src/components/Sessions.tsx`
- Modified `openProfile()` to pass `_resolved: true` flag
- Added localStorage persistence for `currentFolderId`
- Updated useEffect to restore navigation state
- Force reload from disk when profiles are unlocked

### `/src/App.tsx`
- Modified `openSshFor()` to skip re-fetching when `_resolved` is true
- Added `_resolved` parameter to function signature

## Testing
- ✅ SSH profiles with folder inheritance connect properly
- ✅ Navigation stays in current folder after connecting
- ✅ Encrypted profiles work correctly after unlock
- ✅ Cache is properly cleared and reloaded on unlock

## Impact
Users can now:
- Use SSH profiles with folder inheritance even when encrypted
- Stay in their current folder when connecting to profiles
- Have a smoother experience with encrypted profiles

Fixes #14
Fixes #15

🤖 Generated with [Claude Code](https://claude.ai/code)