### PR TITLE
fix: Integrate AI release notes generation into CI/CD (Issue #17)

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -51,15 +51,36 @@ jobs:
           
       - name: Generate Release Notes
         id: release-notes
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
-          # Get the last tag
+          # Get the last tag for fallback
           LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          echo "last_tag=$LAST_TAG" >> $GITHUB_OUTPUT
           
-          # Generate changelog
-          if [ -n "$LAST_TAG" ]; then
-            CHANGELOG=$(git log $LAST_TAG..HEAD --pretty=format:"- %s" --no-merges | head -20)
+          # Try to generate AI release notes
+          if [ -n "$OPENAI_API_KEY" ]; then
+            echo "Generating AI release notes..."
+            if node tools/generate-release-notes.mjs --since-tag --out release-notes.md; then
+              echo "AI release notes generated successfully"
+              CHANGELOG=$(cat release-notes.md)
+            else
+              echo "AI generation failed, falling back to git log"
+              # Fallback to simple git log
+              if [ -n "$LAST_TAG" ]; then
+                CHANGELOG=$(git log $LAST_TAG..HEAD --pretty=format:"- %s" --no-merges | head -20)
+              else
+                CHANGELOG=$(git log --pretty=format:"- %s" --no-merges | head -20)
+              fi
+            fi
           else
-            CHANGELOG=$(git log --pretty=format:"- %s" --no-merges | head -20)
+            echo "OPENAI_API_KEY not set, using git log"
+            # Fallback to simple git log
+            if [ -n "$LAST_TAG" ]; then
+              CHANGELOG=$(git log $LAST_TAG..HEAD --pretty=format:"- %s" --no-merges | head -20)
+            else
+              CHANGELOG=$(git log --pretty=format:"- %s" --no-merges | head -20)
+            fi
           fi
           
           # Escape for GitHub Actions
@@ -103,7 +124,7 @@ jobs:
             ${{ steps.release-notes.outputs.changelog }}
             
             ---
-            [View all commits](https://github.com/${{ github.repository }}/compare/${{ steps.get-version.outputs.last_tag }}...v${{ steps.get-version.outputs.version }})
+            [View all commits](https://github.com/${{ github.repository }}/compare/${{ steps.release-notes.outputs.last_tag }}...v${{ steps.get-version.outputs.version }})
           draft: false
           prerelease: true
           generate_release_notes: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,23 +38,53 @@ jobs:
       
       - name: Generate changelog
         id: changelog
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           # Get the previous tag
           PREV_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
           
-          # Generate changelog
-          echo "## What's Changed" > changelog.md
-          echo "" >> changelog.md
-          
-          if [ -n "$PREV_TAG" ]; then
-            git log $PREV_TAG..HEAD --pretty=format:"- %s (%an)" --no-merges >> changelog.md
+          # Try to generate AI release notes
+          if [ -n "$OPENAI_API_KEY" ]; then
+            echo "Generating AI release notes..."
+            if node tools/generate-release-notes.mjs --since-tag --out changelog.md; then
+              echo "AI release notes generated successfully"
+              # Add link to full changelog at the end
+              echo "" >> changelog.md
+              echo "---" >> changelog.md
+              echo "**Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREV_TAG}...v${{ steps.version.outputs.version }}" >> changelog.md
+            else
+              echo "AI generation failed, falling back to git log"
+              # Fallback to simple changelog
+              echo "## What's Changed" > changelog.md
+              echo "" >> changelog.md
+              
+              if [ -n "$PREV_TAG" ]; then
+                git log $PREV_TAG..HEAD --pretty=format:"- %s (%an)" --no-merges >> changelog.md
+              else
+                git log --pretty=format:"- %s (%an)" --no-merges -20 >> changelog.md
+              fi
+              
+              echo "" >> changelog.md
+              echo "" >> changelog.md
+              echo "**Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREV_TAG}...v${{ steps.version.outputs.version }}" >> changelog.md
+            fi
           else
-            git log --pretty=format:"- %s (%an)" --no-merges -20 >> changelog.md
+            echo "OPENAI_API_KEY not set, using git log"
+            # Fallback to simple changelog
+            echo "## What's Changed" > changelog.md
+            echo "" >> changelog.md
+            
+            if [ -n "$PREV_TAG" ]; then
+              git log $PREV_TAG..HEAD --pretty=format:"- %s (%an)" --no-merges >> changelog.md
+            else
+              git log --pretty=format:"- %s (%an)" --no-merges -20 >> changelog.md
+            fi
+            
+            echo "" >> changelog.md
+            echo "" >> changelog.md
+            echo "**Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREV_TAG}...v${{ steps.version.outputs.version }}" >> changelog.md
           fi
-          
-          echo "" >> changelog.md
-          echo "" >> changelog.md
-          echo "**Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREV_TAG}...v${{ steps.version.outputs.version }}" >> changelog.md
       
       - name: Create tag
         run: |


### PR DESCRIPTION
## Summary
This PR integrates the existing AI release notes script into our CI/CD pipelines to automatically generate meaningful release notes instead of showing static templates.

## Changes
- ✨ Updated AI script to use `gpt-5` model as requested
- 🐛 Fixed commit parsing issues when commit bodies contain special characters
- 🔧 Integrated AI script into both `build-release.yml` and `release.yml` workflows
- 🔄 Added fallback mechanism to use git log if AI generation fails
- 🔐 Added support for `OPENAI_API_KEY` secret in GitHub Actions

## Technical Details
### Script Fixes
- Fixed issue where commit bodies with dashes were causing git command failures
- Added proper SHA escaping using `--` separator in git commands
- Improved commit parsing to handle multi-line commit bodies correctly

### Workflow Integration
- Both workflows now attempt to generate AI release notes first
- If OpenAI API key is not set or generation fails, falls back to simple git log
- Release notes are properly escaped for GitHub Actions output

## Testing
- Tested script locally with dry-run mode ✅
- Verified proper error handling with invalid API key ✅
- Confirmed fallback mechanism works correctly ✅

## Next Steps
To enable AI release notes:
1. Add `OPENAI_API_KEY` secret to repository settings
2. The next release will automatically use AI-generated notes

Fixes #17

🤖 Generated with [Claude Code](https://claude.ai/code)