### PR TITLE
fix: Fix port forwarding sessionId parameter bug

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1079,7 +1079,7 @@ export default function App() {
                       
                       // Trigger the forward activation
                       import('@/types/ipc').then(({ sshOpenForward }) => {
-                        sshOpenForward(sessionId, forward);
+                        sshOpenForward({ sessionId, forward });
                       });
                     }
                   },
@@ -1949,7 +1949,7 @@ export default function App() {
               
               // Trigger the forward activation
               import('@/types/ipc').then(({ sshOpenForward }) => {
-                sshOpenForward(customPortDialog.sessionId, forward);
+                sshOpenForward({ sessionId: customPortDialog.sessionId, forward });
               });
               
               // Show confirmation


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
This PR fixes the port forwarding bug where the `sessionId` parameter was not being passed correctly to the `ssh_open_forward` Tauri command, causing port forwards to fail with "missing required key sessionId" error.

## Problem
The `sshOpenForward` function expects a single object parameter with `sessionId` and `forward` properties:
```typescript
sshOpenForward({ sessionId: string, forward: PortForward })
```

However, in two places it was being called incorrectly with separate arguments:
```typescript
sshOpenForward(sessionId, forward)  // ❌ Wrong
```

## Solution
Fixed both incorrect function calls to pass a single object:
1. Line 1082: Quick action port forward
2. Line 1952: Custom port dialog forward

## Test Plan
- [x] Connect to SSH session
- [x] Open Ports panel
- [x] Click to activate a detected port - should work without error
- [x] Use "Custom Forward" option - should work without error
- [x] Verify port forwarding is actually established

Fixes #26

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)