### PR TITLE
fix: Prevent duplicate settings tabs when clicking Settings button

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1573,24 +1573,27 @@ export default function App() {
         setActiveTab(sessionsId);
       }));
       unlisteners.push(await listen('menu:settings', () => {
-        // Open settings tab - check if it already exists
-        const existingSettings = tabs.find(t => t.kind === 'settings');
-        if (existingSettings) {
-          setActiveTab(existingSettings.id);
-        } else {
-          const settingsTab: Tab = {
-            id: crypto.randomUUID(),
-            kind: 'settings',
-            cwd: null,
-            panes: [],
-            activePane: null,
-            status: {},
-            title: 'Settings',
-            layoutShape: { type: 'leaf' }
-          };
-          setTabs(prev => [...prev, settingsTab]);
-          setActiveTab(settingsTab.id);
-        }
+        setTabs(prev => {
+          // Check if settings tab already exists
+          const existingSettings = prev.find(t => t.kind === 'settings');
+          if (existingSettings) {
+            setActiveTab(existingSettings.id);
+            return prev; // No change to tabs
+          } else {
+            const settingsTab: Tab = {
+              id: crypto.randomUUID(),
+              kind: 'settings',
+              cwd: null,
+              panes: [],
+              activePane: null,
+              status: {},
+              title: 'Settings',
+              layoutShape: { type: 'leaf' }
+            };
+            setActiveTab(settingsTab.id);
+            return [...prev, settingsTab];
+          }
+        });
       }));
       
       // Edit menu events


### PR DESCRIPTION
## Summary
This PR fixes the issue where clicking the Settings button creates duplicate settings tabs instead of activating the existing one.

## Problem
The Settings button always created new settings tabs, even when one already existed. This was due to a React closure issue where the `tabs` array in the event listener was stale.

## Solution
- Use functional `setState` to access the current tabs state
- Check for existing settings tab using up-to-date state  
- Only create new settings tab if none exists
- Activate existing settings tab if found

## Testing
- [x] Build passes
- [x] Settings button opens new tab on first click
- [x] Settings button activates existing tab on subsequent clicks
- [x] No duplicate settings tabs can be created

## Changes Made
- Modified the `menu:settings` event listener in `App.tsx` to use functional state update pattern
- This ensures we always check against the current tabs array, not a stale closure value

Fixes #28