### PR TITLE
fix: Correct wiki file path in publish-wiki.sh script

### DIFF
--- a/scripts/publish-wiki.sh
+++ b/scripts/publish-wiki.sh
@@ -38,6 +38,9 @@ else
   fi
 fi
 
+# Save the original repo directory
+repo_dir=$(pwd)
+
 tmp_dir=$(mktemp -d 2>/dev/null || mktemp -d -t 'wiki')
 trap 'rm -rf "$tmp_dir"' EXIT
 
@@ -63,7 +66,7 @@ cd "$tmp_dir"
 git config user.name "${GIT_AUTHOR_NAME:-github-actions}"
 git config user.email "${GIT_AUTHOR_EMAIL:-github-actions@users.noreply.github.com}"
 rm -f ./*.md
-cp -v ../wiki/*.md .
+cp -v "$repo_dir"/wiki/*.md .
 
 git add -A
 if git diff --cached --quiet; then


### PR DESCRIPTION
## Summary
- Fixed the wiki publishing script that was failing in CI with "cannot stat '../wiki/*.md'" error
- The script now correctly references wiki files from the repository root

## Problem
The `publish-wiki.sh` script was failing because after cloning the wiki repo to a temp directory and changing into it, the relative path `../wiki/*.md` was pointing to the wrong location (parent of temp dir instead of the original repo).

## Solution
- Save the original repository directory before creating the temp directory
- Use the absolute path `$repo_dir/wiki/*.md` to copy wiki files

## Testing
The script will now correctly:
1. Clone the wiki repo to a temp directory
2. Copy markdown files from the repository's `wiki/` folder
3. Commit and push changes to the wiki repo

Fixes #32