### PR TITLE
fix: Get previous tag for release notes comparison when on a tag

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -54,8 +54,17 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
-          # Get the last tag for fallback
-          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          # When running on a tag, get the PREVIOUS tag for comparison
+          # If we're on a tag, git describe returns the current tag, so we need the one before it
+          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            # Get the second most recent tag
+            LAST_TAG=$(git tag --sort=-version:refname | head -2 | tail -1 2>/dev/null || echo "")
+            echo "Running on tag, using previous tag: $LAST_TAG"
+          else
+            # On branch, get the most recent tag
+            LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+            echo "Running on branch, using last tag: $LAST_TAG"
+          fi
           echo "last_tag=$LAST_TAG" >> $GITHUB_OUTPUT
           
           # Try to generate AI release notes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jaterm",
-  "version": "1.4.0",
+  "version": "1.4.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jaterm"
-version = "1.4.0"
+version = "1.4.4"
 description = "JATerm Tauri backend"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "JaTerm",
-  "version": "1.4.0",
+  "version": "1.4.4",
   "identifier": "com.kobozo.jaterm",
   "build": {
     "beforeDevCommand": "pnpm vite",

--- a/tools/generate-release-notes.mjs
+++ b/tools/generate-release-notes.mjs
@@ -57,7 +57,20 @@ function printHelp() {
 }
 
 function lastTag() {
-  try { return run('git describe --tags --abbrev=0'); } catch { return undefined; }
+  try { 
+    // Check if HEAD is currently tagged
+    const headTag = run('git describe --exact-match --tags HEAD 2>/dev/null || echo ""').trim();
+    if (headTag) {
+      // HEAD is tagged, get the previous tag
+      console.error(`[release-notes] HEAD is at tag ${headTag}, getting previous tag`);
+      const tags = run('git tag --sort=-version:refname').split('\n').filter(Boolean);
+      return tags.length > 1 ? tags[1] : tags[0];
+    }
+    // HEAD is not tagged, get the most recent tag
+    return run('git describe --tags --abbrev=0');
+  } catch { 
+    return undefined; 
+  }
 }
 
 function resolveRange(args) {


### PR DESCRIPTION
## Summary
Fixes the issue where release notes show "no changes" by properly comparing with the previous tag instead of the current tag.

## Problem
When the release workflow triggers on a tag push (e.g., v1.4.3), it was comparing v1.4.3..v1.4.3 which results in no changes. This happened because `git describe --tags --abbrev=0` returns the current tag when HEAD is already tagged.

## Solution
1. **Workflow Detection**: The workflow now detects if it's running on a tag (`refs/tags/*`) and uses `git tag --sort=-version:refname | head -2 | tail -1` to get the previous tag
2. **Script Detection**: The generate-release-notes.mjs script also checks if HEAD is tagged and automatically gets the previous tag for comparison
3. **Version Sorting**: Uses version-aware sorting to ensure tags like v1.10.0 come after v1.9.0

## Testing
- When running on tag v1.4.3, it will compare v1.4.2..v1.4.3
- When running on a branch, it will compare the last tag..HEAD
- Handles edge cases like single tag or no tags gracefully

Fixes #34