### PR TITLE
fix: Ensure all tags are fetched in GitHub Actions for release notes

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -25,6 +25,9 @@ jobs:
       upload_url: ${{ steps.create-release.outputs.upload_url }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history and tags
+          fetch-tags: true
       
       - name: Get version
         id: get-version
@@ -54,12 +57,29 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
+          # Debug: Show available tags
+          echo "=== Available tags (first 10) ==="
+          git tag --sort=-version:refname | head -10 || echo "No tags found"
+          
+          echo "=== Current HEAD ==="
+          git describe --exact-match --tags HEAD 2>/dev/null || echo "Not on a tag"
+          
           # When running on a tag, get the PREVIOUS tag for comparison
           # If we're on a tag, git describe returns the current tag, so we need the one before it
           if [[ "${{ github.ref }}" == refs/tags/* ]]; then
             # Get the second most recent tag
             LAST_TAG=$(git tag --sort=-version:refname | head -2 | tail -1 2>/dev/null || echo "")
             echo "Running on tag, using previous tag: $LAST_TAG"
+            
+            # Verify we got a different tag
+            CURRENT_TAG="${{ github.ref_name }}"
+            if [[ "$LAST_TAG" == "$CURRENT_TAG" ]]; then
+              echo "ERROR: Previous tag is same as current tag!"
+              echo "Attempting alternative method..."
+              # Try to get the tag before the current one
+              LAST_TAG=$(git tag --sort=-version:refname | grep -v "^${CURRENT_TAG}$" | head -1 || echo "")
+              echo "Alternative previous tag: $LAST_TAG"
+            fi
           else
             # On branch, get the most recent tag
             LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
@@ -211,6 +231,9 @@ jobs:
     
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history and tags
+          fetch-tags: true
       
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -990,6 +1013,9 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/heads/release/')
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history and tags
+          fetch-tags: true
       
       - name: Download all artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Summary
Fixes issue #36 where release notes were showing "no changes" because GitHub Actions was only fetching the current tag due to shallow cloning.

## Problem
The workflow was using shallow checkout which only fetches minimal history. When running on a tag (like during releases), this meant only the current tag was available, causing the release notes generator to compare v1.4.4..v1.4.4 instead of v1.4.3..v1.4.4.

## Solution
- Added `fetch-depth: 0` to all checkout steps to fetch full history
- Added `fetch-tags: true` to ensure all tags are available
- Added debug output to verify tags are being fetched correctly

## Testing
Created local test script that confirmed:
- Default checkout (shallow) only has current tag
- With `fetch-depth: 0`, all tags are available
- The release notes generator correctly detects when HEAD is on a tag and gets the previous tag

## Related Issues
Fixes #36