### PR TITLE
Fix missing refs in RemoteTerminalPane causing crash on SSH session close

### DIFF
--- a/src/components/RemoteTerminalPane.tsx
+++ b/src/components/RemoteTerminalPane.tsx
@@ -28,6 +28,8 @@ export default function RemoteTerminalPane({ id, desiredCwd, onCwd, onFocusPane,
   const correctedRef = useRef(false);
   const openedAtRef = useRef<number>(Date.now());
   const decoderRef = useRef<TextDecoder | null>(null);
+  const writeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const writeBufferRef = useRef<string>('');
   const IS_DEV = import.meta.env.DEV;
   
   // Get terminal settings


### PR DESCRIPTION
## Summary
- Fixes #69 - ReferenceError when closing SSH terminal sessions
- Adds missing `writeTimerRef` and `writeBufferRef` declarations

## Problem
The cleanup function in `RemoteTerminalPane` was referencing `writeTimerRef` and `writeBufferRef` that were never declared, causing a ReferenceError when closing tabs with SSH sessions.

## Solution
Added the missing ref declarations at the component level:
- `writeTimerRef`: Used to track write operation timeouts
- `writeBufferRef`: Used to buffer write data

## Test plan
- [x] Open SSH connection
- [x] Close SSH terminal tab
- [x] Verify no ReferenceError in console
- [x] Verify session closes properly