### PR TITLE
Fix SSH split operations blocking existing channels

### DIFF
--- a/src/components/RemoteTerminalPane.tsx
+++ b/src/components/RemoteTerminalPane.tsx
@@ -28,6 +28,8 @@ export default function RemoteTerminalPane({ id, desiredCwd, onCwd, onFocusPane,
   const correctedRef = useRef(false);
   const openedAtRef = useRef<number>(Date.now());
   const decoderRef = useRef<TextDecoder | null>(null);
+  const writeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const writeBufferRef = useRef<string>('');
   const IS_DEV = import.meta.env.DEV;
   
   // Get terminal settings


### PR DESCRIPTION
## Summary
- Fixes #70 - Remote terminal split operations causing blank screen and blocked input
- Fixes #69 - Also includes fix for missing refs causing crashes (from parent branch)

## Problem
When performing split operations on SSH terminals, the existing channel would become unresponsive or close unexpectedly. This was caused by the SSH session's blocking mode being changed during new channel creation, which affected all existing channels on that session.

## Root Cause
1. When creating a new SSH channel for split, the code was:
   - Setting the entire SSH session to blocking mode
   - Creating the new channel
   - Setting the session back to non-blocking mode
2. These mode changes affected ALL channels on the session, causing:
   - Existing channels to receive unexpected EOF
   - Read operations to block or fail
   - "channel not found" errors

## Solution
- Check if other channels exist before changing blocking mode
- Only change to blocking mode when creating the first channel
- Preserve existing mode when additional channels are created
- Avoid redundant mode changes after channel creation

## Test plan
- [x] Open SSH connection
- [x] Split terminal horizontally/vertically
- [x] Verify both terminals remain responsive
- [x] Verify input works in both terminals
- [x] Verify no "channel not found" errors
- [x] Test multiple splits (3+ terminals)

## Related Issues
This PR builds on #73 which fixed the ReferenceError issue. Both fixes are needed for proper SSH split functionality.