### PR TITLE
feat: Implement command palette with VS Code-style interface (Issue #41)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@xterm/addon-canvas": "^0.7.0",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/xterm": "^5.5.0",
+    "fuse.js": "^7.1.0",
     "monaco-editor": "^0.52.2",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@xterm/xterm':
         specifier: ^5.5.0
         version: 5.5.0
+      fuse.js:
+        specifier: ^7.1.0
+        version: 7.1.0
       monaco-editor:
         specifier: ^0.52.2
         version: 0.52.2
@@ -602,6 +605,10 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  fuse.js@7.1.0:
+    resolution: {integrity: sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==}
+    engines: {node: '>=10'}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -1192,6 +1199,8 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
+
+  fuse.js@7.1.0: {}
 
   gensync@1.0.0-beta.2: {}
 

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,0 +1,425 @@
+import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import Fuse from 'fuse.js';
+import { Command, CommandCategory } from '@/types/commands';
+import { commandRegistry } from '@/services/commandRegistry';
+import { useToasts } from '@/store/toasts';
+
+interface CommandPaletteProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const categoryIcons: Record<CommandCategory, string> = {
+  [CommandCategory.Terminal]: '⌨️',
+  [CommandCategory.SSH]: '🔐',
+  [CommandCategory.Git]: '🔀',
+  [CommandCategory.Settings]: '⚙️',
+  [CommandCategory.Theme]: '🎨',
+  [CommandCategory.Ports]: '🔌',
+  [CommandCategory.Session]: '💾',
+  [CommandCategory.View]: '👁️',
+  [CommandCategory.File]: '📁',
+};
+
+export const CommandPalette: React.FC<CommandPaletteProps> = ({ isOpen, onClose }) => {
+  const [searchQuery, setSearchQuery] = useState('');
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [allCommands, setAllCommands] = useState<Command[]>([]);
+  const [filteredCommands, setFilteredCommands] = useState<Command[]>([]);
+  const [recentCommands, setRecentCommands] = useState<Command[]>([]);
+  const [isExecuting, setIsExecuting] = useState(false);
+  
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const itemRefs = useRef<(HTMLDivElement | null)[]>([]);
+  const { show } = useToasts();
+
+  // Load commands from registry
+  useEffect(() => {
+    const loadCommands = () => {
+      const commands = commandRegistry.getEnabled();
+      setAllCommands(commands);
+      const recent = commandRegistry.getRecentCommands(5);
+      setRecentCommands(recent);
+    };
+
+    loadCommands();
+    const unsubscribe = commandRegistry.onChange(loadCommands);
+    return unsubscribe;
+  }, []);
+
+  // Initialize Fuse for fuzzy search
+  const fuse = useMemo(() => {
+    return new Fuse(allCommands, {
+      keys: ['label', 'category', 'keywords', 'description'],
+      threshold: 0.3,
+      includeScore: true,
+      shouldSort: true,
+    });
+  }, [allCommands]);
+
+  // Filter commands based on search query
+  useEffect(() => {
+    if (!searchQuery.trim()) {
+      // Show recent commands when no search
+      const categorized = groupCommandsByCategory(allCommands);
+      if (recentCommands.length > 0) {
+        setFilteredCommands([...recentCommands, ...categorized]);
+      } else {
+        setFilteredCommands(categorized);
+      }
+      setSelectedIndex(0);
+      return;
+    }
+
+    // Handle search prefixes
+    let query = searchQuery;
+    let filtered: Command[] = [];
+
+    if (query.startsWith('>')) {
+      // Commands only (default behavior)
+      query = query.substring(1).trim();
+    } else if (query.startsWith(':')) {
+      // Settings commands
+      query = query.substring(1).trim();
+      const settingsCommands = allCommands.filter(
+        cmd => cmd.category === CommandCategory.Settings
+      );
+      const settingsFuse = new Fuse(settingsCommands, {
+        keys: ['label', 'keywords', 'description'],
+        threshold: 0.3,
+      });
+      filtered = query ? settingsFuse.search(query).map(r => r.item) : settingsCommands;
+    } else if (query.startsWith('@')) {
+      // SSH commands
+      query = query.substring(1).trim();
+      const sshCommands = allCommands.filter(
+        cmd => cmd.category === CommandCategory.SSH
+      );
+      const sshFuse = new Fuse(sshCommands, {
+        keys: ['label', 'keywords', 'description'],
+        threshold: 0.3,
+      });
+      filtered = query ? sshFuse.search(query).map(r => r.item) : sshCommands;
+    } else if (query.startsWith('#')) {
+      // Git commands
+      query = query.substring(1).trim();
+      const gitCommands = allCommands.filter(
+        cmd => cmd.category === CommandCategory.Git
+      );
+      const gitFuse = new Fuse(gitCommands, {
+        keys: ['label', 'keywords', 'description'],
+        threshold: 0.3,
+      });
+      filtered = query ? gitFuse.search(query).map(r => r.item) : gitCommands;
+    } else {
+      // Regular fuzzy search
+      filtered = fuse.search(query).map(result => result.item);
+    }
+
+    setFilteredCommands(filtered);
+    setSelectedIndex(0);
+  }, [searchQuery, allCommands, fuse, recentCommands]);
+
+  // Group commands by category
+  const groupCommandsByCategory = (commands: Command[]): Command[] => {
+    const grouped = new Map<CommandCategory, Command[]>();
+    
+    commands.forEach(cmd => {
+      const category = cmd.category;
+      if (!grouped.has(category)) {
+        grouped.set(category, []);
+      }
+      grouped.get(category)!.push(cmd);
+    });
+
+    const result: Command[] = [];
+    grouped.forEach((cmds) => {
+      result.push(...cmds);
+    });
+    
+    return result;
+  };
+
+  // Handle keyboard navigation
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      switch (e.key) {
+        case 'ArrowDown':
+          e.preventDefault();
+          setSelectedIndex(prev => 
+            prev < filteredCommands.length - 1 ? prev + 1 : prev
+          );
+          break;
+        case 'ArrowUp':
+          e.preventDefault();
+          setSelectedIndex(prev => prev > 0 ? prev - 1 : 0);
+          break;
+        case 'Enter':
+          e.preventDefault();
+          if (filteredCommands[selectedIndex]) {
+            executeCommand(filteredCommands[selectedIndex]);
+          }
+          break;
+        case 'Escape':
+          e.preventDefault();
+          onClose();
+          break;
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, selectedIndex, filteredCommands, onClose]);
+
+  // Auto-scroll to selected item
+  useEffect(() => {
+    const selectedItem = itemRefs.current[selectedIndex];
+    if (selectedItem && listRef.current) {
+      const listRect = listRef.current.getBoundingClientRect();
+      const itemRect = selectedItem.getBoundingClientRect();
+      
+      if (itemRect.bottom > listRect.bottom) {
+        selectedItem.scrollIntoView({ block: 'end', behavior: 'smooth' });
+      } else if (itemRect.top < listRect.top) {
+        selectedItem.scrollIntoView({ block: 'start', behavior: 'smooth' });
+      }
+    }
+  }, [selectedIndex]);
+
+  // Focus input when opened
+  useEffect(() => {
+    if (isOpen && inputRef.current) {
+      inputRef.current.focus();
+      setSearchQuery('');
+      setSelectedIndex(0);
+    }
+  }, [isOpen]);
+
+  const executeCommand = useCallback(async (command: Command) => {
+    if (isExecuting) return;
+    
+    setIsExecuting(true);
+    try {
+      await commandRegistry.execute(command.id);
+      onClose();
+    } catch (error) {
+      show({
+        title: 'Command failed',
+        message: error instanceof Error ? error.message : 'Unknown error',
+        kind: 'error',
+      });
+    } finally {
+      setIsExecuting(false);
+    }
+  }, [isExecuting, onClose, show]);
+
+  if (!isOpen) return null;
+
+  const renderCommand = (command: Command, index: number, isRecent = false) => {
+    const isSelected = index === selectedIndex;
+    const icon = categoryIcons[command.category] || '📋';
+    
+    return (
+      <div
+        key={`${isRecent ? 'recent-' : ''}${command.id}`}
+        ref={el => itemRefs.current[index] = el}
+        onClick={() => executeCommand(command)}
+        onMouseEnter={() => setSelectedIndex(index)}
+        style={{
+          padding: '8px 16px',
+          display: 'flex',
+          alignItems: 'center',
+          gap: '12px',
+          backgroundColor: isSelected ? 'rgba(255, 255, 255, 0.1)' : 'transparent',
+          cursor: 'pointer',
+          borderLeft: isSelected ? '2px solid #0078d4' : '2px solid transparent',
+        }}
+      >
+        <span style={{ fontSize: '16px', width: '20px', textAlign: 'center' }}>
+          {icon}
+        </span>
+        <div style={{ flex: 1 }}>
+          <div style={{ 
+            display: 'flex', 
+            alignItems: 'center', 
+            gap: '8px',
+            color: '#fff',
+          }}>
+            <span>{command.label}</span>
+            {isRecent && (
+              <span style={{ 
+                fontSize: '10px', 
+                padding: '2px 6px', 
+                backgroundColor: 'rgba(255, 255, 255, 0.1)',
+                borderRadius: '4px',
+                color: '#999',
+              }}>
+                RECENT
+              </span>
+            )}
+          </div>
+          {command.description && (
+            <div style={{ fontSize: '12px', color: '#999', marginTop: '2px' }}>
+              {command.description}
+            </div>
+          )}
+        </div>
+        {command.shortcut && (
+          <kbd style={{
+            padding: '2px 6px',
+            backgroundColor: 'rgba(255, 255, 255, 0.1)',
+            borderRadius: '4px',
+            fontSize: '12px',
+            color: '#999',
+            fontFamily: 'monospace',
+          }}>
+            {command.shortcut}
+          </kbd>
+        )}
+      </div>
+    );
+  };
+
+  const showRecentSection = !searchQuery && recentCommands.length > 0;
+  const mainCommands = showRecentSection 
+    ? filteredCommands.filter(cmd => !recentCommands.includes(cmd))
+    : filteredCommands;
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        backgroundColor: 'rgba(0, 0, 0, 0.8)',
+        display: 'flex',
+        alignItems: 'flex-start',
+        justifyContent: 'center',
+        paddingTop: '10vh',
+        zIndex: 10000,
+      }}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) {
+          onClose();
+        }
+      }}
+    >
+      <div
+        style={{
+          width: '80%',
+          maxWidth: '800px',
+          backgroundColor: '#1e1e1e',
+          borderRadius: '8px',
+          border: '1px solid #333',
+          boxShadow: '0 20px 60px rgba(0, 0, 0, 0.5)',
+          overflow: 'hidden',
+          maxHeight: '70vh',
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        {/* Search Input */}
+        <div style={{
+          padding: '16px',
+          borderBottom: '1px solid #333',
+        }}>
+          <input
+            ref={inputRef}
+            type="text"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder="Type to search commands... (> commands, : settings, @ SSH, # Git)"
+            style={{
+              width: '100%',
+              padding: '12px',
+              fontSize: '16px',
+              backgroundColor: '#2d2d2d',
+              border: '1px solid #444',
+              borderRadius: '4px',
+              color: '#fff',
+              outline: 'none',
+            }}
+          />
+        </div>
+
+        {/* Results */}
+        <div
+          ref={listRef}
+          style={{
+            flex: 1,
+            overflowY: 'auto',
+            overflowX: 'hidden',
+          }}
+        >
+          {filteredCommands.length === 0 ? (
+            <div style={{
+              padding: '32px',
+              textAlign: 'center',
+              color: '#999',
+            }}>
+              {searchQuery ? 'No commands found' : 'No commands available'}
+            </div>
+          ) : (
+            <>
+              {showRecentSection && (
+                <>
+                  <div style={{
+                    padding: '8px 16px',
+                    color: '#999',
+                    fontSize: '12px',
+                    textTransform: 'uppercase',
+                    borderBottom: '1px solid #333',
+                  }}>
+                    Recent Commands
+                  </div>
+                  {recentCommands.map((cmd, idx) => renderCommand(cmd, idx, true))}
+                  
+                  {mainCommands.length > 0 && (
+                    <div style={{
+                      padding: '8px 16px',
+                      color: '#999',
+                      fontSize: '12px',
+                      textTransform: 'uppercase',
+                      borderBottom: '1px solid #333',
+                      marginTop: '8px',
+                    }}>
+                      All Commands
+                    </div>
+                  )}
+                </>
+              )}
+              
+              {mainCommands.map((cmd, idx) => {
+                const actualIndex = showRecentSection ? idx + recentCommands.length : idx;
+                return renderCommand(cmd, actualIndex, false);
+              })}
+            </>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div style={{
+          padding: '8px 16px',
+          borderTop: '1px solid #333',
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          fontSize: '12px',
+          color: '#999',
+        }}>
+          <div>
+            <kbd>↑↓</kbd> Navigate • <kbd>Enter</kbd> Execute • <kbd>Esc</kbd> Close
+          </div>
+          <div>
+            {filteredCommands.length} command{filteredCommands.length !== 1 ? 's' : ''}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/services/commandRegistry.ts
+++ b/src/services/commandRegistry.ts
@@ -1,0 +1,162 @@
+import { Command, CommandCategory, CommandHistory } from '@/types/commands';
+
+const STORAGE_KEY = 'jaterm_command_history';
+const MAX_RECENT_COMMANDS = 10;
+const MAX_HISTORY_SIZE = 100;
+
+class CommandRegistry {
+  private commands: Map<string, Command> = new Map();
+  private history: CommandHistory[] = [];
+  private listeners: ((commands: Command[]) => void)[] = [];
+
+  constructor() {
+    this.loadHistory();
+  }
+
+  register(command: Command): void {
+    this.commands.set(command.id, command);
+    this.notifyListeners();
+  }
+
+  registerAll(commands: Command[]): void {
+    commands.forEach(cmd => this.commands.set(cmd.id, cmd));
+    this.notifyListeners();
+  }
+
+  unregister(commandId: string): void {
+    this.commands.delete(commandId);
+    this.notifyListeners();
+  }
+
+  get(commandId: string): Command | undefined {
+    return this.commands.get(commandId);
+  }
+
+  getAll(): Command[] {
+    return Array.from(this.commands.values());
+  }
+
+  getByCategory(category: CommandCategory): Command[] {
+    return this.getAll().filter(cmd => cmd.category === category);
+  }
+
+  getVisible(): Command[] {
+    return this.getAll().filter(cmd => {
+      if (cmd.visible && !cmd.visible()) return false;
+      return true;
+    });
+  }
+
+  getEnabled(): Command[] {
+    return this.getVisible().filter(cmd => {
+      if (cmd.enabled && !cmd.enabled()) return false;
+      return true;
+    });
+  }
+
+  async execute(commandId: string): Promise<void> {
+    const command = this.commands.get(commandId);
+    if (!command) {
+      throw new Error(`Command not found: ${commandId}`);
+    }
+
+    if (command.enabled && !command.enabled()) {
+      throw new Error(`Command is disabled: ${commandId}`);
+    }
+
+    // Record in history
+    this.recordUsage(commandId);
+
+    // Execute the command
+    await command.action();
+  }
+
+  getRecentCommands(limit = MAX_RECENT_COMMANDS): Command[] {
+    const sortedHistory = [...this.history].sort((a, b) => {
+      // Calculate frecency score (frequency + recency)
+      const now = Date.now();
+      const aRecency = 1 / (now - a.timestamp + 1);
+      const bRecency = 1 / (now - b.timestamp + 1);
+      const aScore = a.frequency * 0.7 + aRecency * 1000000 * 0.3;
+      const bScore = b.frequency * 0.7 + bRecency * 1000000 * 0.3;
+      return bScore - aScore;
+    });
+
+    const recentCommands: Command[] = [];
+    for (const entry of sortedHistory) {
+      const command = this.commands.get(entry.commandId);
+      if (command && (!command.visible || command.visible())) {
+        recentCommands.push(command);
+        if (recentCommands.length >= limit) break;
+      }
+    }
+
+    return recentCommands;
+  }
+
+  private recordUsage(commandId: string): void {
+    const existing = this.history.find(h => h.commandId === commandId);
+    
+    if (existing) {
+      existing.frequency++;
+      existing.timestamp = Date.now();
+    } else {
+      this.history.push({
+        commandId,
+        timestamp: Date.now(),
+        frequency: 1,
+      });
+    }
+
+    // Limit history size
+    if (this.history.length > MAX_HISTORY_SIZE) {
+      // Remove least frequently used items
+      this.history.sort((a, b) => b.frequency - a.frequency);
+      this.history = this.history.slice(0, MAX_HISTORY_SIZE);
+    }
+
+    this.saveHistory();
+  }
+
+  private loadHistory(): void {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored) {
+        this.history = JSON.parse(stored);
+      }
+    } catch (error) {
+      console.warn('Failed to load command history:', error);
+      this.history = [];
+    }
+  }
+
+  private saveHistory(): void {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(this.history));
+    } catch (error) {
+      console.warn('Failed to save command history:', error);
+    }
+  }
+
+  clearHistory(): void {
+    this.history = [];
+    this.saveHistory();
+  }
+
+  onChange(listener: (commands: Command[]) => void): () => void {
+    this.listeners.push(listener);
+    return () => {
+      const index = this.listeners.indexOf(listener);
+      if (index > -1) {
+        this.listeners.splice(index, 1);
+      }
+    };
+  }
+
+  private notifyListeners(): void {
+    const commands = this.getAll();
+    this.listeners.forEach(listener => listener(commands));
+  }
+}
+
+export const commandRegistry = new CommandRegistry();

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -1,0 +1,43 @@
+export enum CommandCategory {
+  Terminal = 'Terminal',
+  SSH = 'SSH',
+  Git = 'Git',
+  Settings = 'Settings',
+  Theme = 'Theme',
+  Ports = 'Ports',
+  Session = 'Session',
+  View = 'View',
+  File = 'File',
+}
+
+export interface Command {
+  id: string;
+  label: string;
+  category: CommandCategory;
+  icon?: string;
+  shortcut?: string;
+  description?: string;
+  action: () => void | Promise<void>;
+  enabled?: () => boolean;
+  visible?: () => boolean;
+  keywords?: string[];
+}
+
+export interface CommandGroup {
+  category: CommandCategory;
+  commands: Command[];
+}
+
+export interface CommandHistory {
+  commandId: string;
+  timestamp: number;
+  frequency: number;
+}
+
+export interface CommandPaletteState {
+  isOpen: boolean;
+  searchQuery: string;
+  selectedIndex: number;
+  filteredCommands: Command[];
+  recentCommands: Command[];
+}

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -21,6 +21,7 @@ export interface Command {
   enabled?: () => boolean;
   visible?: () => boolean;
   keywords?: string[];
+  subCommands?: () => Command[] | Promise<Command[]>;
 }
 
 export interface CommandGroup {


### PR DESCRIPTION
## Summary
- Implements a VS Code-style command palette triggered by Cmd/Ctrl+Shift+P
- Adds fuzzy search, nested commands, and profile integration
- Fixes keyboard shortcut to work globally, even when terminal is focused

## Features
✨ **Command Palette Interface**
- Global keyboard shortcut (Cmd/Ctrl+Shift+P) works even when terminal is focused
- Fuzzy search with Fuse.js for intelligent command discovery
- Visual categories with icons for better organization
- Keyboard navigation with arrow keys and Enter to execute

✨ **Profile Integration**
- SSH and local profiles are directly searchable
- "New Tab" command shows profile selection as nested commands
- Profiles use resolved settings with inheritance to prevent master key prompts

✨ **User Experience**
- Recent commands tracked with frecency algorithm
- Search prefixes (>, :, @, #) for category filtering
- Escape key navigation for backing out of submenus
- Loading states and error handling

## Technical Changes
- Added command registry service for centralized command management
- Implemented navigation stack for nested command flows
- Fixed SSH profile loading to use resolved settings with `_resolved` flag
- Added helpful error messages for macOS local network permission issues

## Fixes
- Keyboard shortcut now checked before input element filtering
- SSH profiles properly resolve inherited settings from parent folders
- Added `is_ip_address()` helper to avoid lowercasing IP addresses
- Improved error messages for network permission issues on macOS

## Testing
- [x] Command palette opens with Cmd/Ctrl+Shift+P
- [x] Works when terminal is focused
- [x] SSH profiles can be opened without master key prompts
- [x] Profile selection from "New Tab" works correctly
- [x] Search finds commands and profiles
- [x] Recent commands are tracked and displayed

Closes #41